### PR TITLE
refactor(error handling): eliminate unsafe unwrap() usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use esp_hal::{
     uart::{Config, RxConfig, Uart},
 };
 use esp_wifi::{init, EspWifiController};
-use log::info;
+use log::{info, warn};
 use static_cell::StaticCell;
 use task::lte::TripData;
 use task::netmgr::net_manager_task;
@@ -67,17 +67,7 @@ async fn main(spawner: Spawner) -> ! {
     let timg1 = TimerGroup::new(peripherals.TIMG1);
     esp_hal_embassy::init(timg1.timer0);
     let trng = &mut *mk_static!(Trng<'static>, Trng::new(peripherals.RNG, peripherals.ADC1));
-    //let trng = &*mk_static!(
-    //    Mutex<Trng<'static>, EspWifiController<'static>>,
-    //    Mutex::new(Trng::new(peripherals.RNG, peripherals.ADC1))
-    //);
-    let init = &*mk_static!(
-        EspWifiController<'static>,
-        init(timg0.timer0, trng.rng, peripherals.RADIO_CLK).unwrap()
-    );
-    let wifi = peripherals.WIFI;
-    let (controller, wifi_interface) = esp_wifi::wifi::new(init, wifi).unwrap();
-    let config = embassy_net::Config::dhcpv4(Default::default());
+
     #[cfg(feature = "wdg")]
     let mut rtc = {
         let mut rtc = Rtc::new(peripherals.LPWR);
@@ -86,24 +76,17 @@ async fn main(spawner: Spawner) -> ! {
         rtc
     };
 
-    let seed = 1234;
-
-    let (stack, runner) = embassy_net::new(
-        wifi_interface.sta,
-        config,
-        mk_static!(StackResources<3>, StackResources::<3>::new()),
-        seed,
-    );
-    let stack = &*mk_static!(Stack, stack);
-
     let uart_tx_pin = peripherals.GPIO23;
     let uart_rx_pin = peripherals.GPIO15;
     let quectel_pen_pin = Output::new(peripherals.GPIO21, Level::High, OutputConfig::default());
     let quectel_dtr_pin = Output::new(peripherals.GPIO22, Level::High, OutputConfig::default());
 
     let config = Config::default().with_rx(RxConfig::default().with_fifo_full_threshold(64));
+    // SAFETY: UART0 is guaranteed to be available and the pins are correctly configured.
+    // If this fails, it's a hardware configuration error, and we cannot proceed.
+    // Note: If UART0 is not available, this will panic, since we cannot use GPS or LTE without it.
     let uart0 = Uart::new(peripherals.UART0, config)
-        .unwrap()
+        .expect("UART0 initialization failed: check hardware configuration")
         .with_rx(uart_rx_pin)
         .with_tx(uart_tx_pin)
         .into_async();
@@ -145,18 +128,64 @@ async fn main(spawner: Spawner) -> ! {
     let (can_rx, _can_tx) = can.split();
 
     let gps_channel = &*GPS_CHANNEL.init(Channel::new());
+
+    let wifi_config = embassy_net::Config::dhcpv4(Default::default());
+
+    // Initialize the WiFi controller but if it fails, we will not proceed with the WiFi tasks. we can still use LTE.
+    'wifi_tasks: {
+        let init = match init(timg0.timer0, trng.rng, peripherals.RADIO_CLK) {
+            Ok(init) => &*mk_static!(EspWifiController<'static>, init),
+            Err(e) => {
+                warn!("Failed to initialize controller: {e:?}");
+                break 'wifi_tasks;
+            }
+        };
+
+        let wifi = peripherals.WIFI;
+        let (controller, wifi_interface) = match esp_wifi::wifi::new(init, wifi) {
+            Ok((c, w)) => (c, w),
+            Err(e) => {
+                warn!("Failed to initialize WiFi: {e:?}");
+                break 'wifi_tasks;
+            }
+        };
+
+        let seed = 1234;
+        let (stack, runner) = embassy_net::new(
+            wifi_interface.sta,
+            wifi_config,
+            mk_static!(StackResources<3>, StackResources::<3>::new()),
+            seed,
+        );
+        let stack = &*mk_static!(Stack, stack);
+        spawner.spawn(connection(controller)).ok();
+        spawner.spawn(net_task(runner)).ok();
+        spawner
+            .spawn(mqtt_handler(
+                stack,
+                channel,
+                gps_channel,
+                peripherals.SHA,
+                peripherals.RSA,
+            ))
+            .ok();
+
+        spawner.spawn(net_manager_task(spawner)).ok();
+        #[cfg(feature = "ota")]
+        //wait until wifi connected
+        {
+            loop {
+                if stack.is_link_up() {
+                    break;
+                }
+                Timer::after(Duration::from_millis(500)).await;
+            }
+            spawner
+                .spawn(ota_handler(spawner, trng, stack))
+                .expect("Failed to spawn OTA handler task");
+        }
+    }
     spawner.spawn(can_receiver(can_rx, channel)).ok();
-    spawner.spawn(connection(controller)).ok();
-    spawner.spawn(net_task(runner)).ok();
-    spawner
-        .spawn(mqtt_handler(
-            stack,
-            channel,
-            gps_channel,
-            peripherals.SHA,
-            peripherals.RSA,
-        ))
-        .ok();
     spawner.spawn(quectel_rx_handler(ingress, uart_rx)).ok();
     spawner
         .spawn(quectel_tx_handler(
@@ -168,21 +197,6 @@ async fn main(spawner: Spawner) -> ! {
             channel,
         ))
         .ok();
-
-    spawner.spawn(net_manager_task(spawner)).ok();
-    #[cfg(feature = "ota")]
-    //wait until wifi connected
-    {
-        loop {
-            if stack.is_link_up() {
-                break;
-            }
-            Timer::after(Duration::from_millis(500)).await;
-        }
-        spawner
-            .spawn(ota_handler(spawner, trng, stack))
-            .expect("Failed to spawn OTA handler task");
-    }
 
     // WDG feed task
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn main(spawner: Spawner) -> ! {
     // If this fails, it's a hardware configuration error, and we cannot proceed.
     // Note: If UART0 is not available, this will panic, since we cannot use GPS or LTE without it.
     let uart0 = Uart::new(peripherals.UART0, config)
-        .expect("UART0 initialization failed: check hardware configuration")
+        .expect("UART0 initialization failed: check hardware configuration") // also panic but it mostly will not happen
         .with_rx(uart_rx_pin)
         .with_tx(uart_tx_pin)
         .into_async();

--- a/src/task/can.rs
+++ b/src/task/can.rs
@@ -36,11 +36,14 @@ pub async fn can_receiver(
                         // if id.as_raw() == MQTT_CAN_PACKET {
                         info!("Receive MQTT CAN packet");
                         // Try to send can frame to wifi task without blocking
-                        let _ = can_channel.try_send(CanFrame {
+                        match can_channel.try_send(CanFrame {
                             id: id.as_raw(),
                             len: frame.dlc() as u8,
                             data,
-                        });
+                        }) {
+                            Ok(_) => info!("[CAN] Frame sent to channel successfully"),
+                            Err(e) => error!("[CAN] Failed to send frame channel {e:?}"),
+                        };
                         // }
                     }
                 }

--- a/src/task/lte.rs
+++ b/src/task/lte.rs
@@ -826,7 +826,7 @@ pub async fn quectel_tx_handler(
                 } else {
                     if is_connected {
                         if let Err(e) = CONN_EVENT_CHAN.try_send(ConnectionEvent::LteUnregistered) {
-                            warn!("[LTE] Failed to send LTE Connected event: {e:?}");
+                            warn!("[LTE] Failed to send LTE Unregistered event: {e:?}");
                         }
                         is_connected = false;
                     }
@@ -859,7 +859,7 @@ pub async fn quectel_tx_handler(
                     Err(e) => {
                         error!("[Quectel] MQTT connection failed: {e:?}");
                         if let Err(e) = CONN_EVENT_CHAN.try_send(ConnectionEvent::LteDisconnected) {
-                            warn!("[LTE] Failed to send LTE Connected event: {e:?}");
+                            warn!("[LTE] Failed to send LTE Disconnected event: {e:?}");
                         }
                         state = State::ErrorConnection;
                     }
@@ -881,7 +881,7 @@ pub async fn quectel_tx_handler(
             State::ErrorConnection => {
                 if is_connected {
                     if let Err(e) = CONN_EVENT_CHAN.try_send(ConnectionEvent::LteDisconnected) {
-                        warn!("[LTE] Failed to send LTE Connected event: {e:?}");
+                        warn!("[LTE] Failed to send LTE Disconnected event: {e:?}");
                     }
                     is_connected = false;
                 }

--- a/src/task/lte.rs
+++ b/src/task/lte.rs
@@ -32,8 +32,26 @@ const REGISTRATION_DENIED: u8 = 3;
 const REGISTRATION_FAILED: u8 = 4;
 const REGISTERED_ROAMING: u8 = 5;
 #[derive(Debug)]
+/// Represents errors that can occur during the upload process.
+///
+/// This enum is used to indicate specific issues that might arise when
+/// attempting to upload data. Each variant corresponds to a distinct
+/// type of error, and appropriate handling should be implemented for
+/// each case.
 pub enum UploadError {
+    /// Indicates that a `heapless::String` exceeded its maximum capacity.
+    ///
+    /// This error occurs when attempting to write more data into a
+    /// `heapless::String` than its allocated size allows. To handle this
+    /// error, ensure that the data being written fits within the string's
+    /// capacity or increase the string's size if possible.
     HeaplessStringOverflow,
+    /// Represents an error that occurred while sending data via the client.
+    ///
+    /// This error is returned when the underlying client fails to send
+    /// data, possibly due to connectivity issues or internal client errors.
+    /// Handling this error might involve retrying the operation or
+    /// checking the client's state.
     ClientSendError,
 }
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/task/netmgr.rs
+++ b/src/task/netmgr.rs
@@ -149,15 +149,15 @@ pub async fn net_manager_task(spawner: Spawner) -> ! {
             if can_switch_to(&status, requested_connection) {
                 perform_net_switch(&mut status, requested_connection).await;
                 if let Err(e) = status_sender.try_send(status) {
-                    warn!("[NETMGR] Failed to send status: {e:?}");
+                    warn!("[NetMgr] Failed to send status: {e:?}");
                 }
 
                 if let Err(e) = active_net_sender.try_send(status.active) {
-                    warn!("[NETMGR] Failed to send active_net: {e:?}");
+                    warn!("[NetMgr] Failed to send active_net: {e:?}");
                 }
 
                 if let Err(e) = active_lte_sender.try_send(status.active) {
-                    warn!("[NETMGR] Failed to send active_lte: {e:?}");
+                    warn!("[NetMgr] Failed to send active_lte: {e:?}");
                 }
             } else {
                 warn!("[NetMgr] Cannot switch to {requested_connection:?} - not available");
@@ -199,7 +199,7 @@ async fn lte_health_monitor(
         // For now, we assume LTE is connected if the state is not None
         if !lte_is_connected() {
             if let Err(e) = event_sender.try_send(ConnectionEvent::LteDisconnected) {
-                warn!("[NETMGR] Failed to send LteDisconnected event: {e:?}");
+                warn!("[NetMgr] Failed to send LteDisconnected event: {e:?}");
             }
         }
     }

--- a/src/task/ota.rs
+++ b/src/task/ota.rs
@@ -136,8 +136,7 @@ pub async fn ota_handler(
         let mut store = KeyStore::new();
         // Set MAC address as device identity - should never fail with a valid MAC
         if let Err(_e) = store.set_item("mac", &mac_str) {
-            log_error!("[OTA] Failed to set MAC address in identity store: {_e:?}");
-            panic!("Cannot create device identity without MAC address");
+            panic!("Cannot create device identity: failed to set MAC address in keystore - this is a critical system error");
         };
 
         store
@@ -209,8 +208,7 @@ pub async fn ota_handler(
     let mut keystore = KeyStore::new();
     for item in &inventory {
         if let Err(_e) = keystore.set_item(&item.name, &item.value) {
-            log_error!("[OTA] Failed to add inventory item '{item.name}': {_e:?}");
-            panic!("Cannot create device inventory");
+            panic!("Cannot create device inventory: failed to add item '{item.name}' to keystore: {_e:?}");
         }
     }
     // Set the inventory

--- a/tests/src/bin/test_ex_flash.rs
+++ b/tests/src/bin/test_ex_flash.rs
@@ -39,16 +39,18 @@ async fn main(_spawner: Spawner) -> ! {
     let miso = peripherals.GPIO20;
     let mosi = peripherals.GPIO19;
     let cs_pin = Output::new(peripherals.GPIO3, Level::High, OutputConfig::default());
-    let spi = Spi::new(
+    let spi = match Spi::new(
         peripherals.SPI2,
         Config::default()
             .with_frequency(Rate::from_khz(100u32))
             .with_mode(Mode::_0), // CPOL = 0, CPHA = 0 (Mode 0 per datasheet)
-    )
-    .unwrap()
-    .with_sck(sclk)
-    .with_mosi(mosi)
-    .with_miso(miso);
+    ) {
+        Ok(spi) => spi.with_sck(sclk).with_mosi(mosi).with_miso(miso),
+        Err(e) => {
+            error!("Failed to initialize SPI: {e:?}");
+            panic!("Cannot continue without flash initialization");
+        }
+    };
 
     // Run the test directly
     info!("Starting flash communication test...");

--- a/tests/src/bin/test_ex_flash.rs
+++ b/tests/src/bin/test_ex_flash.rs
@@ -48,7 +48,7 @@ async fn main(_spawner: Spawner) -> ! {
         Ok(spi) => spi.with_sck(sclk).with_mosi(mosi).with_miso(miso),
         Err(e) => {
             error!("Failed to initialize SPI: {e:?}");
-            panic!("Cannot continue without flash initialization");
+            panic!("Cannot continue without flash initialization"); //We cannot continue without flash
         }
     };
 
@@ -64,7 +64,7 @@ async fn main(_spawner: Spawner) -> ! {
         Ok(()) => info!("Flash initialized successfully."),
         Err(e) => {
             error!("Flash initialization failed: {e:?}");
-            panic!("Cannot continue without flash initialization");
+            panic!("Cannot continue without flash initialization"); //We cannot continue without flash
         }
     }
 

--- a/tests/src/bin/test_fs.rs
+++ b/tests/src/bin/test_fs.rs
@@ -267,16 +267,18 @@ async fn main(_spawner: Spawner) -> ! {
     let miso = peripherals.GPIO20;
     let mosi = peripherals.GPIO19;
     let cs = Output::new(peripherals.GPIO3, Level::High, OutputConfig::default());
-    let spi = Spi::new(
+    let spi = match Spi::new(
         peripherals.SPI2,
         Config::default()
             .with_frequency(Rate::from_khz(100u32))
             .with_mode(Mode::_0),
-    )
-    .unwrap()
-    .with_sck(sclk)
-    .with_mosi(mosi)
-    .with_miso(miso);
+    ) {
+        Ok(spi) => spi.with_sck(sclk).with_mosi(mosi).with_miso(miso),
+        Err(e) => {
+            error!("Failed to initialize SPI: {e:?}");
+            panic!("Cannot continue without flash");
+        }
+    };
 
     let mut flash = W25Q128FVSG::new(spi, cs);
 

--- a/tests/src/bin/test_fs.rs
+++ b/tests/src/bin/test_fs.rs
@@ -276,7 +276,7 @@ async fn main(_spawner: Spawner) -> ! {
         Ok(spi) => spi.with_sck(sclk).with_mosi(mosi).with_miso(miso),
         Err(e) => {
             error!("Failed to initialize SPI: {e:?}");
-            panic!("Cannot continue without flash");
+            panic!("Cannot continue without flash"); //We cannot continue without flash
         }
     };
 
@@ -287,7 +287,7 @@ async fn main(_spawner: Spawner) -> ! {
         Ok(()) => info!("✓ Flash initialized successfully"),
         Err(e) => {
             error!("✗ Flash initialization failed: {e:?}");
-            panic!("Cannot continue without flash");
+            panic!("Cannot continue without flash"); //We cannot continue without flash
         }
     }
 


### PR DESCRIPTION
Hi anh @TuEmb,
I have made the following improvements to our source code:

- Eliminated unsafe usages of `unwrap()`. For cases where `unwrap()` is still used, explanatory comments have been added to justify their safety.
- Ensured that the return values of all functions are properly handled. Instances of `let _ = ...` have been removed or replaced with appropriate error-handling logic.
- Verified that the project builds successfully.

Please review at your convenience.  
Thank you for your time and support!